### PR TITLE
Fix typo in ImplantMarket Javadoc

### DIFF
--- a/src/main/java/org/example/implants/ImplantMarket.java
+++ b/src/main/java/org/example/implants/ImplantMarket.java
@@ -50,7 +50,7 @@ public class ImplantMarket {
         this.minProbOfFail = minProbOfFail;
     }
     /**
-     * Kupuwanie implant na podstawie zaproponowanej ceny.
+     * Kupowanie implantu na podstawie zaproponowanej ceny.
      *<p>
      * @param proposedPrice zaproponowana cena za implant
      * @return nowy implant z określoną szansą awarii


### PR DESCRIPTION
## Summary
- fix Polish typos in `buyImplant` Javadoc

## Testing
- `./gradlew test` *(fails: unable to download Gradle wrapper)*

------
https://chatgpt.com/codex/tasks/task_e_68584908e3288322b70f65d60a68da7c